### PR TITLE
THORN-2182: close response when mapping exception

### DIFF
--- a/implementation/src/main/java/io/smallrye/restclient/DefaultResponseExceptionMapper.java
+++ b/implementation/src/main/java/io/smallrye/restclient/DefaultResponseExceptionMapper.java
@@ -28,6 +28,10 @@ class DefaultResponseExceptionMapper implements ResponseExceptionMapper {
 
     @Override
     public Throwable toThrowable(Response response) {
+        try {
+            response.bufferEntity();
+        } catch (Exception ignored) {}
+        response.close();
         return new WebApplicationException("Unknown error, status code " + response.getStatus(), response);
     }
 


### PR DESCRIPTION
Motivation
----------
To keep the client working after a failure to parse response (for details, please take a look into the related THORN issue)

Modifications
-------------
`DefaultExceptionMapper` has been modified to close the response. Additionally, it buffers the response's entity so that the entity is still available (required by the TCK)

Result
------
The client is reusable after a failure.

**NOTE** a test for this changes is planned to be added to the Thorntail code: https://github.com/thorntail/thorntail/pull/1131 (due to difficulties setting up JSON parsing in testsuite here)